### PR TITLE
feat: 카카오 이메일 동의 안받아도 로그인 되도록 설정

### DIFF
--- a/workit/src/main/java/workit/service/AuthService.java
+++ b/workit/src/main/java/workit/service/AuthService.java
@@ -137,11 +137,11 @@ public class AuthService {
 
             JsonElement element = JsonParser.parseString(result.toString());
 
-            boolean hasEmail = element.getAsJsonObject().get("kakao_account").getAsJsonObject().get("has_email").getAsBoolean();
-            if(!hasEmail){
-                throw new CustomException(ResponseCode.DISAGREE_KAKAO_EMAIL);
+            boolean disagreeEmail = element.getAsJsonObject().get("kakao_account").getAsJsonObject().get("email_needs_agreement").getAsBoolean();
+            String email = "";
+            if(!disagreeEmail){
+                email = element.getAsJsonObject().get("kakao_account").getAsJsonObject().get("email").getAsString();
             }
-            String email = element.getAsJsonObject().get("kakao_account").getAsJsonObject().get("email").getAsString();
             String nickname = element.getAsJsonObject().get("properties").getAsJsonObject().get("nickname").getAsString();
 
             String accessToken = getAccessToken(new SignupRequestDto(email, nickname, SocialType.KAKAO));


### PR DESCRIPTION
## 관련 이슈
- Resolved: #16

## 작업 내용
- 카카오 이메일 동의받지 않아도 로그인 되도록 설정

<!-- 아 맞다! Assignee, Reviewer, Label 설정! 😇 -->
